### PR TITLE
fix: Validate TLS hostname

### DIFF
--- a/manifests/gtfsrt-vp-poller/base/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/base/kustomization.yaml
@@ -2,7 +2,7 @@ resources:
   - deployment.yaml
 
 configMapGenerator:
-  - name:  gtfsrt-vp-poller
+  - name: gtfsrt-vp-poller
     literals:
     - HEALTH_CHECK_PORT=8080
     - HTTP_IS_HTTP2_USED=false
@@ -17,5 +17,5 @@ configMapGenerator:
     - PULSAR_IS_URL_IN_MESSAGE_PROPERTIES=false
     - PULSAR_OAUTH2_ISSUER_URL=https://auth.streamnative.cloud
     - PULSAR_OAUTH2_KEY_PATH=/secrets/pulsar-oauth2-key
-    - PULSAR_TLS_VALIDATE_HOSTNAME=false
+    - PULSAR_TLS_VALIDATE_HOSTNAME=true
     - PULSAR_TOPIC=TO_BE_FILLED_IN_OVERLAY

--- a/manifests/journey-matcher/base/kustomization.yaml
+++ b/manifests/journey-matcher/base/kustomization.yaml
@@ -35,4 +35,4 @@ configMapGenerator:
       - PULSAR_GTFSRT_SUBSCRIPTION=journey-matcher-gtfsrt-sub
       - PULSAR_OAUTH2_ISSUER_URL=https://auth.streamnative.cloud
       - PULSAR_OAUTH2_KEY_PATH=/secrets/pulsar-oauth2-key
-      - PULSAR_TLS_VALIDATE_HOSTNAME=false
+      - PULSAR_TLS_VALIDATE_HOSTNAME=true

--- a/manifests/mqtt-deduplicator/base/kustomization.yaml
+++ b/manifests/mqtt-deduplicator/base/kustomization.yaml
@@ -21,7 +21,7 @@ configMapGenerator:
     # PULSAR_PRODUCER_TOPIC: "TO_BE_FILLED_IN_OVERLAY"
     - "PULSAR_SUBSCRIPTION=mqtt-deduplicator-sub"
     # Optional
-    - "PULSAR_TLS_VALIDATE_HOSTNAME=false"
+    - "PULSAR_TLS_VALIDATE_HOSTNAME=true"
 
 secretGenerator:
   - name: mqtt-deduplicator

--- a/manifests/vehicle-registry-poller/base/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/base/kustomization.yaml
@@ -18,5 +18,5 @@ configMapGenerator:
     - PULSAR_IS_URL_IN_MESSAGE_PROPERTIES=false
     - PULSAR_OAUTH2_ISSUER_URL=https://auth.streamnative.cloud
     - PULSAR_OAUTH2_KEY_PATH=/secrets/pulsar-oauth2-key
-    - PULSAR_TLS_VALIDATE_HOSTNAME=false
+    - PULSAR_TLS_VALIDATE_HOSTNAME=true
     - PULSAR_TOPIC=TO_BE_FILLED_IN_OVERLAY


### PR DESCRIPTION
After pulsar-client updates, all microservices should be able validate
TLS hostnames.
