### PR TITLE
fix: Add ClientId suffix for mqtt-pulsar-forwarder

### DIFF
--- a/manifests/mqtt-pulsar-forwarder/base/kustomization.yaml
+++ b/manifests/mqtt-pulsar-forwarder/base/kustomization.yaml
@@ -18,6 +18,7 @@ configMapGenerator:
     literals:
     - HEALTH_CHECK_PORT=8080
     - MQTT_CLEAN_SESSION=false
+    - MQTT_CLIENT_ID_SUFFIX_LENGTH=16
     - MQTT_PASSWORD_PATH=/secrets/mqtt-password
     - MQTT_QOS=2
     - MQTT_USERNAME_PATH=/secrets/mqtt-username


### PR DESCRIPTION
The different instances in different AZs must each have a unique
ClientId or they will keep disconnecting each other. Add a random suffix
to ensure uniqueness.
