### PR TITLE
fix: Set initialDelaySeconds for profiler startup

### DIFF
--- a/manifests/vehicle-anonymization-profiler/base/deployment.yaml
+++ b/manifests/vehicle-anonymization-profiler/base/deployment.yaml
@@ -34,13 +34,13 @@ spec:
                   port: liveness-port
                 failureThreshold: 1
                 periodSeconds: 10
-                initialDelaySeconds: 5
               startupProbe:
                 httpGet:
                   path: /healthz
                   port: liveness-port
                 failureThreshold: 30
                 periodSeconds: 2
+                initialDelaySeconds: 5
               securityContext:
                 allowPrivilegeEscalation: false
                 capabilities:


### PR DESCRIPTION
startupProbe is the one that keeps giving us HTTP status 500.
