### PR TITLE
Add Lahti APC onboarding manifests

### DIFF
--- a/manifests/anonymizer/base/kustomization.yaml
+++ b/manifests/anonymizer/base/kustomization.yaml
@@ -11,7 +11,8 @@ configMapGenerator:
       - >-
         AUTHORITY_MAP=[
           ["221","fi:kuopio"],
-          ["209","fi:jyvaskyla"]
+          ["209","fi:jyvaskyla"],
+          ["223","fi:lahti"]
         ]
       - HEALTH_CHECK_PORT=8080
       - PINO_LOG_LEVEL=info

--- a/manifests/gtfsrt-vp-poller/lahti/base/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/base/kustomization.yaml
@@ -1,0 +1,15 @@
+nameSuffix: -fi-lahti
+resources:
+- ../../base
+
+commonLabels:
+  app.kubernetes.io/instance: gtfsrt-vp-poller-fi-lahti
+  app: gtfsrt-vp-poller-fi-lahti
+
+secretGenerator:
+  - name: gtfsrt-vp-poller
+    literals:
+    - http-username=foo
+    - http-password=bar
+    options:
+      disableNameSuffixHash: true

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/dev/history-limit.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/dev/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gtfsrt-vp-poller-fi-lahti
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/dev/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/dev/kustomization.yaml
@@ -1,0 +1,18 @@
+namespace: dev
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: gtfsrt-vp-poller-fi-lahti
+    behavior: merge
+    literals:
+      - "HTTP_PASSWORD_PATH=/secrets/http-password"
+      - "HTTP_URL=https://data.waltti.fi/lahti/api/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_USERNAME_PATH=/secrets/http-username"
+      - "PINO_LOG_LEVEL=debug"
+      - "PULSAR_TOPIC=persistent://apc-sandbox/source/gtfsrt-vp-fi-lahti"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:alpha"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+patches:
+  - path: history-limit.yaml
+  - path: resource-bursting.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/dev/resource-bursting.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/dev/resource-bursting.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gtfsrt-vp-poller
+spec:
+  template:
+    spec:
+      containers:
+        - name: gtfsrt-vp-poller
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 100Mi

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/prod/history-limit.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/prod/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gtfsrt-vp-poller-fi-lahti
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/prod/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/prod/kustomization.yaml
@@ -1,0 +1,17 @@
+namespace: prod
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: gtfsrt-vp-poller-fi-lahti
+    behavior: merge
+    literals:
+      - "HTTP_PASSWORD_PATH=/secrets/http-password"
+      - "HTTP_URL=https://data.waltti.fi/lahti/api/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_USERNAME_PATH=/secrets/http-username"
+      - "PINO_LOG_LEVEL=info"
+      - "PULSAR_TOPIC=persistent://apc-prod/source/gtfsrt-vp-fi-lahti"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:prod"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+patches:
+  - path: history-limit.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/staging/history-limit.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/staging/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gtfsrt-vp-poller-fi-lahti
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/staging/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/staging/kustomization.yaml
@@ -1,0 +1,18 @@
+namespace: staging
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: gtfsrt-vp-poller-fi-lahti
+    behavior: merge
+    literals:
+      - "HTTP_PASSWORD_PATH=/secrets/http-password"
+      - "HTTP_URL=https://data.waltti.fi/lahti/api/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_USERNAME_PATH=/secrets/http-username"
+      - "PINO_LOG_LEVEL=info"
+      - "PULSAR_TOPIC=persistent://apc-staging/source/gtfsrt-vp-fi-lahti"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:beta"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+patches:
+  - path: history-limit.yaml
+  - path: resource-bursting.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/staging/resource-bursting.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/staging/resource-bursting.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gtfsrt-vp-poller
+spec:
+  template:
+    spec:
+      containers:
+        - name: gtfsrt-vp-poller
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 100Mi

--- a/manifests/journey-matcher/overlays/dev/kustomization.yaml
+++ b/manifests/journey-matcher/overlays/dev/kustomization.yaml
@@ -6,7 +6,7 @@ configMapGenerator:
   - name: journey-matcher
     behavior: merge
     literals:
-      - 'FEED_MAP=[["persistent://apc-sandbox/source/splitted-gtfsrt-vp-fi-kuopio",["fi:kuopio","221","Europe/Helsinki"]],["persistent://apc-sandbox/source/splitted-gtfsrt-vp-fi-jyvaskyla",["fi:jyvaskyla","209","Europe/Helsinki"]]]'
+      - 'FEED_MAP=[["persistent://apc-sandbox/source/splitted-gtfsrt-vp-fi-kuopio",["fi:kuopio","221","Europe/Helsinki"]],["persistent://apc-sandbox/source/splitted-gtfsrt-vp-fi-jyvaskyla",["fi:jyvaskyla","209","Europe/Helsinki"]],["persistent://apc-sandbox/source/splitted-gtfsrt-vp-fi-lahti",["fi:lahti","223","Europe/Helsinki"]]]'
       - 'PINO_LOG_LEVEL=debug'
       - "PULSAR_APC_CONSUMER_TOPICS_PATTERN=persistent://apc-sandbox/deduplicated/mqtt-apc-from-vehicle-deduplicated"
       - "PULSAR_VEHICLE_REGISTRY_CONSUMER_TOPICS_PATTERN=persistent://apc-sandbox/source/vehicle-catalogue-.*"

--- a/manifests/journey-matcher/overlays/prod/kustomization.yaml
+++ b/manifests/journey-matcher/overlays/prod/kustomization.yaml
@@ -6,7 +6,7 @@ configMapGenerator:
   - name: journey-matcher
     behavior: merge
     literals:
-      - 'FEED_MAP=[["persistent://apc-prod/source/splitted-gtfsrt-vp-fi-kuopio",["fi:kuopio","221","Europe/Helsinki"]],["persistent://apc-prod/source/splitted-gtfsrt-vp-fi-jyvaskyla",["fi:jyvaskyla","209","Europe/Helsinki"]]]'
+      - 'FEED_MAP=[["persistent://apc-prod/source/splitted-gtfsrt-vp-fi-kuopio",["fi:kuopio","221","Europe/Helsinki"]],["persistent://apc-prod/source/splitted-gtfsrt-vp-fi-jyvaskyla",["fi:jyvaskyla","209","Europe/Helsinki"]],["persistent://apc-prod/source/splitted-gtfsrt-vp-fi-lahti",["fi:lahti","223","Europe/Helsinki"]]]'
       - 'PINO_LOG_LEVEL=info'
       - "PULSAR_APC_CONSUMER_TOPICS_PATTERN=persistent://apc-prod/deduplicated/mqtt-apc-from-vehicle-deduplicated"
       - "PULSAR_VEHICLE_REGISTRY_CONSUMER_TOPICS_PATTERN=persistent://apc-prod/source/vehicle-catalogue-.*"
@@ -18,4 +18,3 @@ configMapGenerator:
 
 patches:
   - path: history-limit.yaml
-

--- a/manifests/journey-matcher/overlays/staging/kustomization.yaml
+++ b/manifests/journey-matcher/overlays/staging/kustomization.yaml
@@ -6,7 +6,7 @@ configMapGenerator:
   - name: journey-matcher
     behavior: merge
     literals:
-      - 'FEED_MAP=[["persistent://apc-staging/source/splitted-gtfsrt-vp-fi-kuopio",["fi:kuopio","221","Europe/Helsinki"]],["persistent://apc-staging/source/splitted-gtfsrt-vp-fi-jyvaskyla",["fi:jyvaskyla","209","Europe/Helsinki"]]]'
+      - 'FEED_MAP=[["persistent://apc-staging/source/splitted-gtfsrt-vp-fi-kuopio",["fi:kuopio","221","Europe/Helsinki"]],["persistent://apc-staging/source/splitted-gtfsrt-vp-fi-jyvaskyla",["fi:jyvaskyla","209","Europe/Helsinki"]],["persistent://apc-staging/source/splitted-gtfsrt-vp-fi-lahti",["fi:lahti","223","Europe/Helsinki"]]]'
       - 'PINO_LOG_LEVEL=info'
       - "PULSAR_APC_CONSUMER_TOPICS_PATTERN=persistent://apc-staging/deduplicated/mqtt-apc-from-vehicle-deduplicated"
       - "PULSAR_VEHICLE_REGISTRY_CONSUMER_TOPICS_PATTERN=persistent://apc-staging/source/vehicle-catalogue-.*"

--- a/manifests/vehicle-anonymization-profiler/overlays/dev/kustomization.yaml
+++ b/manifests/vehicle-anonymization-profiler/overlays/dev/kustomization.yaml
@@ -8,27 +8,22 @@ configMapGenerator:
     literals:
       - "PINO_LOG_LEVEL=debug"
       - "IS_FRESH_START=false"
-      # FIXME: Leaving this here as an example on what to do when multiple
-      # municipalities start using Waltti-APC.
-      # - >-
-      #   PULSAR_CATALOGUE_READERS=[
-      #     {
-      #       "feedPublisherId": "fi:jyvaskyla",
-      #       "name": "vehicle-anonymization-profiler-catalogue-reader-fi-jyvaskyla",
-      #       "topic": "persistent://apc-sandbox/source/vehicle-catalogue-fi-jyvaskyla"
-      #     },
-      #     {
-      #       "feedPublisherId": "fi:kuopio",
-      #       "name": "vehicle-anonymization-profiler-catalogue-reader-fi-kuopio",
-      #       "topic": "persistent://apc-sandbox/source/vehicle-catalogue-fi-kuopio"
-      #     }
-      #   ]
       - >-
         PULSAR_CATALOGUE_READERS=[
           {
             "feedPublisherId": "fi:jyvaskyla",
             "name": "vehicle-anonymization-profiler-catalogue-reader-fi-jyvaskyla",
             "topic": "persistent://apc-sandbox/source/vehicle-catalogue-fi-jyvaskyla"
+          },
+          {
+            "feedPublisherId": "fi:kuopio",
+            "name": "vehicle-anonymization-profiler-catalogue-reader-fi-kuopio",
+            "topic": "persistent://apc-sandbox/source/vehicle-catalogue-fi-kuopio"
+          },
+          {
+            "feedPublisherId": "fi:lahti",
+            "name": "vehicle-anonymization-profiler-catalogue-reader-fi-lahti",
+            "topic": "persistent://apc-sandbox/source/vehicle-catalogue-fi-lahti"
           }
         ]
       # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:alpha"

--- a/manifests/vehicle-anonymization-profiler/overlays/prod/kustomization.yaml
+++ b/manifests/vehicle-anonymization-profiler/overlays/prod/kustomization.yaml
@@ -14,6 +14,16 @@ configMapGenerator:
             "feedPublisherId": "fi:jyvaskyla",
             "name": "vehicle-anonymization-profiler-catalogue-reader-fi-jyvaskyla",
             "topic": "persistent://apc-prod/source/vehicle-catalogue-fi-jyvaskyla"
+          },
+          {
+            "feedPublisherId": "fi:kuopio",
+            "name": "vehicle-anonymization-profiler-catalogue-reader-fi-kuopio",
+            "topic": "persistent://apc-prod/source/vehicle-catalogue-fi-kuopio"
+          },
+          {
+            "feedPublisherId": "fi:lahti",
+            "name": "vehicle-anonymization-profiler-catalogue-reader-fi-lahti",
+            "topic": "persistent://apc-prod/source/vehicle-catalogue-fi-lahti"
           }
         ]
       # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:prod"

--- a/manifests/vehicle-anonymization-profiler/overlays/staging/kustomization.yaml
+++ b/manifests/vehicle-anonymization-profiler/overlays/staging/kustomization.yaml
@@ -14,6 +14,16 @@ configMapGenerator:
             "feedPublisherId": "fi:jyvaskyla",
             "name": "vehicle-anonymization-profiler-catalogue-reader-fi-jyvaskyla",
             "topic": "persistent://apc-staging/source/vehicle-catalogue-fi-jyvaskyla"
+          },
+          {
+            "feedPublisherId": "fi:kuopio",
+            "name": "vehicle-anonymization-profiler-catalogue-reader-fi-kuopio",
+            "topic": "persistent://apc-staging/source/vehicle-catalogue-fi-kuopio"
+          },
+          {
+            "feedPublisherId": "fi:lahti",
+            "name": "vehicle-anonymization-profiler-catalogue-reader-fi-lahti",
+            "topic": "persistent://apc-staging/source/vehicle-catalogue-fi-lahti"
           }
         ]
       # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:beta"

--- a/manifests/vehicle-position-splitter/lahti/base/kustomization.yaml
+++ b/manifests/vehicle-position-splitter/lahti/base/kustomization.yaml
@@ -1,0 +1,15 @@
+nameSuffix: -fi-lahti
+resources:
+- ../../base
+
+commonLabels:
+  app.kubernetes.io/instance: vehicle-position-splitter-fi-lahti
+  app: vehicle-position-splitter-fi-lahti
+
+secretGenerator:
+  - name: vehicle-position-splitter
+    literals:
+    - http-username=foo
+    - http-password=bar
+    options:
+      disableNameSuffixHash: true

--- a/manifests/vehicle-position-splitter/lahti/overlays/dev/history-limit.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/dev/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-position-splitter
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/vehicle-position-splitter/lahti/overlays/dev/kustomization.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/dev/kustomization.yaml
@@ -1,0 +1,23 @@
+namespace: dev
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: vehicle-position-splitter-fi-lahti
+    behavior: merge
+    literals:
+      - 'FEED_MAP=[["persistent://apc-sandbox/source/gtfsrt-vp-fi-lahti","fi:lahti"],["persistent://apc-sandbox/source/vehicle-catalogue-fi-lahti","fi:lahti"]]'
+      - "PINO_LOG_LEVEL=info"
+      - "PULSAR_GTFSRT_SUBSCRIPTION=vehicle-position-splitter-lahti-sub"
+      - "PULSAR_APC_SUBSCRIPTION=vehicle-position-splitter-lahti-sub"
+      - "PULSAR_GTFSRT_CONSUMER_TOPICS_PATTERN=persistent://apc-sandbox/source/gtfsrt-vp-fi-lahti"
+      - "PULSAR_PRODUCER_TOPIC=persistent://apc-sandbox/source/splitted-gtfsrt-vp-fi-lahti"
+      - "PULSAR_VEHICLE_READER_TOPIC=persistent://apc-sandbox/source/vehicle-catalogue-fi-lahti"
+      - "PULSAR_CACHE_READER_NAME=cache-reader"
+      - "PULSAR_VEHICLE_READER_NAME=vehicle-reader"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:alpha"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+
+patches:
+  - path: history-limit.yaml
+  - path: resource-bursting.yaml

--- a/manifests/vehicle-position-splitter/lahti/overlays/dev/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/dev/resource-bursting.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-position-splitter
+spec:
+  template:
+    spec:
+      containers:
+        - name: vehicle-position-splitter
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 100Mi

--- a/manifests/vehicle-position-splitter/lahti/overlays/prod/history-limit.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/prod/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-position-splitter
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/vehicle-position-splitter/lahti/overlays/prod/kustomization.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/prod/kustomization.yaml
@@ -1,0 +1,22 @@
+namespace: prod
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: vehicle-position-splitter-fi-lahti
+    behavior: merge
+    literals:
+      - 'FEED_MAP=[["persistent://apc-prod/source/gtfsrt-vp-fi-lahti","fi:lahti"],["persistent://apc-prod/source/vehicle-catalogue-fi-lahti","fi:lahti"]]'
+      - "PINO_LOG_LEVEL=info"
+      - "PULSAR_GTFSRT_SUBSCRIPTION=vehicle-position-splitter-lahti-sub"
+      - "PULSAR_APC_SUBSCRIPTION=vehicle-position-splitter-lahti-sub"
+      - "PULSAR_GTFSRT_CONSUMER_TOPICS_PATTERN=persistent://apc-prod/source/gtfsrt-vp-fi-lahti"
+      - "PULSAR_PRODUCER_TOPIC=persistent://apc-prod/source/splitted-gtfsrt-vp-fi-lahti"
+      - "PULSAR_VEHICLE_READER_TOPIC=persistent://apc-prod/source/vehicle-catalogue-fi-lahti"
+      - "PULSAR_CACHE_READER_NAME=cache-reader"
+      - "PULSAR_VEHICLE_READER_NAME=vehicle-reader"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:prod"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+
+patches:
+  - path: history-limit.yaml

--- a/manifests/vehicle-position-splitter/lahti/overlays/staging/history-limit.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/staging/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-position-splitter
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/vehicle-position-splitter/lahti/overlays/staging/kustomization.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/staging/kustomization.yaml
@@ -1,0 +1,23 @@
+namespace: staging
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: vehicle-position-splitter-fi-lahti
+    behavior: merge
+    literals:
+      - 'FEED_MAP=[["persistent://apc-staging/source/gtfsrt-vp-fi-lahti","fi:lahti"],["persistent://apc-staging/source/vehicle-catalogue-fi-lahti","fi:lahti"]]'
+      - "PINO_LOG_LEVEL=info"
+      - "PULSAR_GTFSRT_SUBSCRIPTION=vehicle-position-splitter-lahti-sub"
+      - "PULSAR_APC_SUBSCRIPTION=vehicle-position-splitter-lahti-sub"
+      - "PULSAR_GTFSRT_CONSUMER_TOPICS_PATTERN=persistent://apc-staging/source/gtfsrt-vp-fi-lahti"
+      - "PULSAR_PRODUCER_TOPIC=persistent://apc-staging/source/splitted-gtfsrt-vp-fi-lahti"
+      - "PULSAR_VEHICLE_READER_TOPIC=persistent://apc-staging/source/vehicle-catalogue-fi-lahti"
+      - "PULSAR_CACHE_READER_NAME=cache-reader"
+      - "PULSAR_VEHICLE_READER_NAME=vehicle-reader"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:beta"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+
+patches:
+  - path: history-limit.yaml
+  - path: resource-bursting.yaml

--- a/manifests/vehicle-position-splitter/lahti/overlays/staging/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/staging/resource-bursting.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-position-splitter
+spec:
+  template:
+    spec:
+      containers:
+        - name: vehicle-position-splitter
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 100Mi

--- a/manifests/vehicle-registry-poller/lahti/base/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/lahti/base/kustomization.yaml
@@ -1,0 +1,15 @@
+nameSuffix: -fi-lahti
+resources:
+- ../../base
+
+commonLabels:
+  app.kubernetes.io/instance: vehicle-registry-fi-lahti
+  app:  vehicle-registry-poller-fi-lahti
+
+secretGenerator:
+  - name: vehicle-registry-poller
+    literals:
+    - http-username=foo
+    - http-password=bar
+    options:
+      disableNameSuffixHash: true

--- a/manifests/vehicle-registry-poller/lahti/overlays/dev/history-limit.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/dev/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-registry-poller-fi-lahti
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/vehicle-registry-poller/lahti/overlays/dev/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/dev/kustomization.yaml
@@ -1,0 +1,18 @@
+namespace: dev
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: vehicle-registry-poller-fi-lahti
+    behavior: merge
+    literals:
+      - "HTTP_PASSWORD_PATH=/secrets/http-password"
+      - "HTTP_URL=https://lahtiadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_USERNAME_PATH=/secrets/http-username"
+      - "PINO_LOG_LEVEL=debug"
+      - "PULSAR_TOPIC=persistent://apc-sandbox/source/vehicle-catalogue-fi-lahti"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:alpha"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+patches:
+  - path: history-limit.yaml
+  - path: resource-bursting.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/dev/resource-bursting.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/dev/resource-bursting.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-registry-poller
+spec:
+  template:
+    spec:
+      containers:
+        - name: vehicle-registry-poller
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 100Mi

--- a/manifests/vehicle-registry-poller/lahti/overlays/prod/history-limit.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/prod/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-registry-poller-fi-lahti
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/vehicle-registry-poller/lahti/overlays/prod/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/prod/kustomization.yaml
@@ -1,0 +1,17 @@
+namespace: prod
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: vehicle-registry-poller-fi-lahti
+    behavior: merge
+    literals:
+      - "HTTP_PASSWORD_PATH=/secrets/http-password"
+      - "HTTP_URL=https://lahtiadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_USERNAME_PATH=/secrets/http-username"
+      - "PINO_LOG_LEVEL=info"
+      - "PULSAR_TOPIC=persistent://apc-prod/source/vehicle-catalogue-fi-lahti"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:prod"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+patches:
+  - path: history-limit.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/staging/history-limit.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/staging/history-limit.yaml
@@ -1,0 +1,6 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-registry-poller-fi-lahti
+spec:
+  revisionHistoryLimit: 2

--- a/manifests/vehicle-registry-poller/lahti/overlays/staging/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/staging/kustomization.yaml
@@ -1,0 +1,18 @@
+namespace: staging
+resources:
+  - ../../base
+
+configMapGenerator:
+  - name: vehicle-registry-poller-fi-lahti
+    behavior: merge
+    literals:
+      - "HTTP_PASSWORD_PATH=/secrets/http-password"
+      - "HTTP_URL=https://lahtiadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_USERNAME_PATH=/secrets/http-username"
+      - "PINO_LOG_LEVEL=info"
+      - "PULSAR_TOPIC=persistent://apc-staging/source/vehicle-catalogue-fi-lahti"
+      # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:beta"
+      - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
+patches:
+  - path: history-limit.yaml
+  - path: resource-bursting.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/staging/resource-bursting.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/staging/resource-bursting.yaml
@@ -1,0 +1,18 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: vehicle-registry-poller
+spec:
+  template:
+    spec:
+      containers:
+        - name: vehicle-registry-poller
+          resources:
+            requests:
+              cpu: 50m
+              memory: 256Mi
+              ephemeral-storage: 100Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
+              ephemeral-storage: 100Mi

--- a/streamnative/environments/sandbox/topics_source.tf
+++ b/streamnative/environments/sandbox/topics_source.tf
@@ -43,11 +43,50 @@ resource "pulsar_topic" "gtfsrt_vp_fi_kuopio" {
   }
 }
 
+resource "pulsar_topic" "gtfsrt_vp_fi_lahti" {
+  tenant     = pulsar_tenant.tenant.tenant
+  namespace  = pulsar_namespace.source.namespace
+  topic_type = "persistent"
+  topic_name = "gtfsrt-vp-fi-lahti"
+  partitions = 0
+
+  permission_grant {
+    role    = "proto-client@waltti.auth.streamnative.cloud"
+    actions = ["produce", "consume", "functions"]
+  }
+}
+
+resource "pulsar_topic" "vehicle_catalogue_fi_lahti" {
+  tenant     = pulsar_tenant.tenant.tenant
+  namespace  = pulsar_namespace.source.namespace
+  topic_type = "persistent"
+  topic_name = "vehicle-catalogue-fi-lahti"
+  partitions = 0
+
+  permission_grant {
+    role    = "proto-client@waltti.auth.streamnative.cloud"
+    actions = ["produce", "consume", "functions"]
+  }
+}
+
 resource "pulsar_topic" "splitted_gtfsrt_vp_fi_kuopio" {
   tenant     = pulsar_tenant.tenant.tenant
   namespace  = pulsar_namespace.source.namespace
   topic_type = "persistent"
   topic_name = "splitted-gtfsrt-vp-fi-kuopio"
+  partitions = 0
+
+  permission_grant {
+    role    = "proto-client@waltti.auth.streamnative.cloud"
+    actions = ["produce", "consume", "functions"]
+  }
+}
+
+resource "pulsar_topic" "splitted_gtfsrt_vp_fi_lahti" {
+  tenant     = pulsar_tenant.tenant.tenant
+  namespace  = pulsar_namespace.source.namespace
+  topic_type = "persistent"
+  topic_name = "splitted-gtfsrt-vp-fi-lahti"
   partitions = 0
 
   permission_grant {

--- a/streamnative/environments/staging/topics_source.tf
+++ b/streamnative/environments/staging/topics_source.tf
@@ -43,11 +43,50 @@ resource "pulsar_topic" "gtfsrt_vp_fi_kuopio" {
   }
 }
 
+resource "pulsar_topic" "gtfsrt_vp_fi_lahti" {
+  tenant     = pulsar_tenant.tenant.tenant
+  namespace  = pulsar_namespace.source.namespace
+  topic_type = "persistent"
+  topic_name = "gtfsrt-vp-fi-lahti"
+  partitions = 0
+
+  permission_grant {
+    role    = "staging-client@waltti.auth.streamnative.cloud"
+    actions = ["produce", "consume", "functions"]
+  }
+}
+
+resource "pulsar_topic" "vehicle_catalogue_fi_lahti" {
+  tenant     = pulsar_tenant.tenant.tenant
+  namespace  = pulsar_namespace.source.namespace
+  topic_type = "persistent"
+  topic_name = "vehicle-catalogue-fi-lahti"
+  partitions = 0
+
+  permission_grant {
+    role    = "staging-client@waltti.auth.streamnative.cloud"
+    actions = ["produce", "consume", "functions"]
+  }
+}
+
 resource "pulsar_topic" "splitted_gtfsrt_vp_fi_kuopio" {
   tenant     = pulsar_tenant.tenant.tenant
   namespace  = pulsar_namespace.source.namespace
   topic_type = "persistent"
   topic_name = "splitted-gtfsrt-vp-fi-kuopio"
+  partitions = 0
+
+  permission_grant {
+    role    = "staging-client@waltti.auth.streamnative.cloud"
+    actions = ["produce", "consume", "functions"]
+  }
+}
+
+resource "pulsar_topic" "splitted_gtfsrt_vp_fi_lahti" {
+  tenant     = pulsar_tenant.tenant.tenant
+  namespace  = pulsar_namespace.source.namespace
+  topic_type = "persistent"
+  topic_name = "splitted-gtfsrt-vp-fi-lahti"
   partitions = 0
 
   permission_grant {


### PR DESCRIPTION
## Summary
- add Lahti GTFS-RT poller, vehicle registry poller, and vehicle position splitter overlays for dev/staging/prod
- add Lahti authority/feed mappings to journey matcher and anonymizer
- add Lahti catalogue readers to vehicle anonymization profiler
- add sandbox/staging Pulsar source topics for Lahti

## Validation
- kustomize build passed for all Lahti overlays
- kustomize build passed for touched journey-matcher, anonymizer, and profiler overlays in dev/staging/prod

## Known blockers
- real Lahti GTFS-RT credentials still need to replace placeholder secrets
- real Lahti vehicle registry URL still needs confirmation; current placeholder host does not resolve
