### PR TITLE
Apply Kuopio and Lahti poller endpoints

### DIFF
--- a/manifests/gtfsrt-vp-poller/kuopio/overlays/dev/kuopio-secret.yaml
+++ b/manifests/gtfsrt-vp-poller/kuopio/overlays/dev/kuopio-secret.yaml
@@ -7,19 +7,14 @@ metadata:
     labels:
         app.kubernetes.io/instance: gtfsrt-vp-poller-fi-kuopio
 data:
-    http-password: ENC[AES256_GCM,data:qf3P3blcIo5pR0Eo4SZaXQ==,iv:Fzv9TfxjwsWmHNXWDhGwPauxL3TJNkfa/arSCue6b/4=,tag:ANpA8/6hXIt4vshGKxvcDQ==,type:str]
-    http-username: ENC[AES256_GCM,data:uNm1WSohNEtWsnWjfZ+6Bg==,iv:2vHEwiX4TMrxok1rHrNJwfHWBaNvL9RNaXCf5t4gqPU=,tag:Ann+52takhHFZQzguy6sig==,type:str]
+    http-password: ENC[AES256_GCM,data:qd7Bio8/zdCAxBL0,iv:YylCXFOfOhNDATvsMHR0eyaBr/p9nvXildCfIj6DFIs=,tag:BX7YNHjunY+UPmtEoCjxVQ==,type:str]
+    http-username: ENC[AES256_GCM,data:yOld8x1tsoc=,iv:no6M4YXfn2uK2hghuw79CSeaUba98jfO5zIDeDTtbbo=,tag:tOYxGL9vz2ODAJJjdMUMfg==,type:str]
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/apc-sandbox/locations/global/keyRings/sops/cryptoKeys/sops-key
           created_at: "2025-11-27T12:11:14Z"
           enc: CiQAQ7huFgUqHw8zLTozT4agHWfeoNUfevSMvY6wKikGmI3ei2kSSQC//AyiiFeuVj9ObElm6ei2ivd9hnnYmOMU4iHSNR92oN+tpVkfR/2bHv9Dxmsq/kt5Fzfn/8hdbwQaVyivY6nLv8xbVkzh5pM=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-11-27T12:11:14Z"
-    mac: ENC[AES256_GCM,data:zNkqhiuJ7rlqBvLDzjIexuLK4jzB4eVT2GxfUVXvKx2aT2G6QxEPYrHKougXtl0j6IjLNZl0FTVI09EY7So0nMLjTVZsvuwKng8i26Q3VQqJYidxdoZ74+KL7t+dbIgL6eeveTBCPefiyY5uxQ88c/RrsMMPEFb5LFoUddP4hqg=,iv:QRcxgc2XKjhEa+KtsUS0PbSSA/srx1VesPPTAyDCOFc=,tag:qbFdYiKal+BoKc97H6VxSg==,type:str]
-    pgp: []
+    lastmodified: "2026-05-22T07:22:25Z"
+    mac: ENC[AES256_GCM,data:WzIYXptux2Qj3a1WVP7psU4nYl3Y8OP/+rWCq8mwQaI5MggkzVFiCkNxzITBJfCCzWp5mfPEG6TO8DmxuMtRyq/6OI2PVuMnfrKUI+vSSX3c5lxdBPjVmI7jIFqvKywBA5ErNDxJhYJxUAJTobnP3yro41vMEFUpBjiOimsbE7o=,iv:0bYH7RaPSh70ugwFkH7PP43HTQzS6wovVljV1Sfn2/o=,tag:EP9HuIBSnGTktCVrrMPRlg==,type:str]
     encrypted_regex: ^(data)$
     version: 3.7.3

--- a/manifests/gtfsrt-vp-poller/kuopio/overlays/dev/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/kuopio/overlays/dev/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://opendatavilkku.mattersoft.fi/rtapi/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_URL=https://vilkku.mattersoft.fi/api/gtfsrealtime/v1.0/feed/vehicleposition"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=debug"
       - "PULSAR_TOPIC=persistent://apc-sandbox/source/gtfsrt-vp-fi-kuopio"

--- a/manifests/gtfsrt-vp-poller/kuopio/overlays/prod/kuopio-secret.yaml
+++ b/manifests/gtfsrt-vp-poller/kuopio/overlays/prod/kuopio-secret.yaml
@@ -10,19 +10,14 @@ metadata:
     labels:
         app.kubernetes.io/instance: gtfsrt-vp-poller-fi-kuopio
 data:
-    http-username: ENC[AES256_GCM,data:qOsN5muSolDKUuSVnVPMiw==,iv:bRBkul9LQwymJqrF+X+jJ4jG48+HO1RejeLiOBvXPN4=,tag:X6rkL0dzgGQEsXOpkS1IfQ==,type:str]
-    http-password: ENC[AES256_GCM,data:MhpWYWwmGoOjdZCYwreN+A==,iv:uxea77vdQKy+sLTa2QQ7zFcYnVQOyqwZgEmmT1NDjug=,tag:SY3St1Nne60+SeKHnDJSNw==,type:str]
+    http-username: ENC[AES256_GCM,data:7LU+cTsMBjI=,iv:c1XQp3MKCOsJUGh+OJH52w7d8xLwUPh8BFAmmUhzFD0=,tag:2v/p7/eqGfuSPwzrSQwxCQ==,type:str]
+    http-password: ENC[AES256_GCM,data:AgLdJM0NxvfPz4CO,iv:MAqsnzxfd5Lftyp14yZeEifBhI1QPRjFTs3z7LLTWzk=,tag:BoB3C3Pp76tb8i7zRC29wQ==,type:str]
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/apc-prod-397611/locations/europe-west3/keyRings/sops/cryptoKeys/sops-key
           created_at: "2025-12-03T11:58:55Z"
           enc: CiQAhLiU4YAtxYMNLRPGuw37fR0m6JAhpdIwSvosjf1l605JuGASSQDOezfyaC3p706J2ZfjmTYz62wz4X1SIh4uF0o7SfNbcH62zTKHz3NAG38F3kqcRGIOd69L8XyWy72+LDcSfDIXrR2Y0SQZkOA=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-12-03T11:58:55Z"
-    mac: ENC[AES256_GCM,data:mW6yTX+ZH/xhBtx7G4UwlXgTEFBVt1pHLd8+itSWOzfwpDGBW30056re5Rf2wfIkFgbbEAAYdxepslqAUrMDUASEIzDWDCtbUgDcayTa/bRl4vl52gmUcOlpSPlf1GkPfpfYMQfwlaZm1uX9+zb2UJOgWq63WZNlUVrgx78JfUo=,iv:WMnlnUazCduj1DtkjR/7g6jDpmkFJWlDni5Kqv8/3Ag=,tag:kAcvAO7T66WyD0+QdRdmcw==,type:str]
-    pgp: []
+    lastmodified: "2026-05-22T07:22:28Z"
+    mac: ENC[AES256_GCM,data:XS9rp4fN3BAz6mgb1Ocky3PTgw4QuwvDpHZk1u/hxWarp4jJT7mOhBXKWhhdhsx7K/WsRNfQLfe5RSWKsNlZbmL8uCsCt3+gxt0VMolfRuGMdFjS9aX2bWtk9iy8m16YxmxzgtPjLIPYmlBrkjuKA/UcTAzL45NSTizs+Nrp9Yo=,iv:BAGIJDgeF3DzDhAvaTpThKPP67f6RhTMikUdhsRlMyI=,tag:K4LCWtKhiv8rZWK8IYQGIw==,type:str]
     encrypted_regex: ^(data)$
     version: 3.7.3

--- a/manifests/gtfsrt-vp-poller/kuopio/overlays/prod/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/kuopio/overlays/prod/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://opendatavilkku.mattersoft.fi/rtapi/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_URL=https://vilkku.mattersoft.fi/api/gtfsrealtime/v1.0/feed/vehicleposition"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-prod/source/gtfsrt-vp-fi-kuopio"

--- a/manifests/gtfsrt-vp-poller/kuopio/overlays/staging/kuopio-secret.yaml
+++ b/manifests/gtfsrt-vp-poller/kuopio/overlays/staging/kuopio-secret.yaml
@@ -7,19 +7,14 @@ metadata:
     labels:
         app.kubernetes.io/instance: gtfsrt-vp-poller-fi-kuopio
 data:
-    http-username: ENC[AES256_GCM,data:hlWjRgHXOO+q+f3n1+zlXQ==,iv:gLU5vXRz1jEy7hvMYYyl4WZw41+zrbsC6BedBUJnd+8=,tag:+2XmCEjf/RK0iXNEod3FSg==,type:str]
-    http-password: ENC[AES256_GCM,data:icUn4sySlF0spfInJBLk1A==,iv:FLWKeunHMwMm6JAAFMW9JaqjItCJs/QH7AJkpW6/APs=,tag:tBLjPdW3OK+n96MYMRYWMA==,type:str]
+    http-username: ENC[AES256_GCM,data:dLzDKwcbR1g=,iv:/IRp1Bkn3TOzBHK5RyS3NeDDKtpbEKwogriO68Ybsnc=,tag:zwRCDGpROXJLZx5Rab7FaQ==,type:str]
+    http-password: ENC[AES256_GCM,data:KMHlMYHvxvR6Koyt,iv:JbkBYbinYv+ViuGWqQeUBFQQ2BCp5vmGcvXYZEbL/W8=,tag:k2by9MDDeWZ2CARvMOAG3Q==,type:str]
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/apc-staging-388907/locations/global/keyRings/sops/cryptoKeys/sops-key
           created_at: "2025-11-27T12:24:41Z"
           enc: CiQAUhREB0aYVP+eThd4Z0or7KmFvm9V711moyGGxlLXEI7+GhcSSQD4ANZeVlkoTENqqXNDxPNI9R3o4RZe5YyyDdzVxGE/Rg6Q7a3PvZl4UKkIBZH36o3iL6GXY2puzjPxsma621Ud692aPPJoJp0=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-11-27T12:24:41Z"
-    mac: ENC[AES256_GCM,data:VW2lH6i4/v8wVGelP583QFRbkYFxDLxmXCTPgZDAw/Be01Ckdg0JwqNK1lTVpTtsW01z8xPN7elCtQZRtmiQxK0Uk56NIN1DWRDcGzi/77jdg2mgXTp7Gc3DI5Y84lohE1VqCmfaHmYGg+MR4vK4bt3tHAePbz6zyjlMaGCYH6w=,iv:WtlWHYwfdHyHCOBL2ivS9vB+msW8k9/LX3tt/cleImI=,tag:OUBqIhbKYGkEaq2BJuycTw==,type:str]
-    pgp: []
+    lastmodified: "2026-05-22T07:22:27Z"
+    mac: ENC[AES256_GCM,data:+qLlh8tFm1vQVeshqQ06Rqv5b7PweUKypy36ZRlMjMJfmYWReDEAUYxEqWbu0NOziIUeMi7dWpOjunR7FNwHoutjzJNQM81xbhiorF9Obgk3DO6cIgxibxfKwWFCkyv9DCytFIAuMxVzBopmFaSc2ACv4HjrK8NHSQJaVZdKNTg=,iv:+07D3yL5CC1/eNjNhq/LtfOhzjcTwzlpDJsy7D1s+JY=,tag:9R1Yxja1euONxMwJz25YHA==,type:str]
     encrypted_regex: ^(data)$
     version: 3.7.3

--- a/manifests/gtfsrt-vp-poller/kuopio/overlays/staging/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/kuopio/overlays/staging/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://opendatavilkku.mattersoft.fi/rtapi/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_URL=https://vilkku.mattersoft.fi/api/gtfsrealtime/v1.0/feed/vehicleposition"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-staging/source/gtfsrt-vp-fi-kuopio"

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/dev/ksops-secret-generator.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/dev/ksops-secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./lahti-secret.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/dev/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/dev/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://data.waltti.fi/lahti/api/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_URL=https://lsl.mattersoft.fi/api/gtfsrealtime/v1.0/feed/vehicleposition"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=debug"
       - "PULSAR_TOPIC=persistent://apc-sandbox/source/gtfsrt-vp-fi-lahti"
@@ -16,3 +16,6 @@ configMapGenerator:
 patches:
   - path: history-limit.yaml
   - path: resource-bursting.yaml
+
+generators:
+  - ./ksops-secret-generator.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/dev/lahti-secret.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/dev/lahti-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gtfsrt-vp-poller-fi-lahti
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+    labels:
+        app.kubernetes.io/instance: gtfsrt-vp-poller-fi-lahti
+data:
+    http-username: ENC[AES256_GCM,data:V1Y+AFeRTco=,iv:qTi5dAciVNpJZVN3qJ+uWn5J3TOfnJxsGbaI8U1wJ1g=,tag:toy61dAQiZJFN61IGQs0KA==,type:str]
+    http-password: ENC[AES256_GCM,data:OC42WAGZdNyZAKtN,iv:GlZJAVyMNNmEgopFtcRF3F7LMu9gnN3gD5UetgRvu18=,tag:ySnGg1BZnkq3RSW6f1GzBQ==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/apc-sandbox/locations/global/keyRings/sops/cryptoKeys/sops-key
+          created_at: "2026-05-22T07:24:27Z"
+          enc: CiQAQ7huFv4lF9z1Pw0vqEgxP6vyn5MI9wWqMsFS8QQIVFa2+kASSAC//Ayi5drf/nqJoomWfJ64241p2ZggP13vAx7bX7wxKhP6GjalqWb35RFtUDJGEdC+OrJ3eWVEmM6CXTuj75Xx5jp6GILk8g==
+    lastmodified: "2026-05-22T07:24:28Z"
+    mac: ENC[AES256_GCM,data:oauqJ5e++e7kPqa5DUPHP/Nj6OWrzvRReMbH1tRBQH1caSGrMKCkHphNmPwc3s/N3dfeLAz88dIoCqhuD4tRJ8VT54tvUza0D0r9vINKnXILrYYcRZF88Iqq5N/1vL+kKuusYVgtEiESbSQMhTwBB9W/o6AnAcA/3aVtPbjuXW0=,iv:dWRwfp8aB3UuZFAyguwWD/jhT1GGuakZHVSwsTYLick=,tag:wG9RyxbHJY21PTX8eC84Og==,type:str]
+    encrypted_regex: ^(data)$
+    version: 3.11.0

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/prod/ksops-secret-generator.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/prod/ksops-secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./lahti-secret.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/prod/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/prod/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://data.waltti.fi/lahti/api/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_URL=https://lsl.mattersoft.fi/api/gtfsrealtime/v1.0/feed/vehicleposition"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-prod/source/gtfsrt-vp-fi-lahti"
@@ -15,3 +15,6 @@ configMapGenerator:
       - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
 patches:
   - path: history-limit.yaml
+
+generators:
+  - ./ksops-secret-generator.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/prod/lahti-secret.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/prod/lahti-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gtfsrt-vp-poller-fi-lahti
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+    labels:
+        app.kubernetes.io/instance: gtfsrt-vp-poller-fi-lahti
+data:
+    http-username: ENC[AES256_GCM,data:+QmFbgBjFIs=,iv:PBcQxc4RsqJ2LqcJ5AQU4JD9aNjlrord01I2uT+9QRI=,tag:jzpDh+exJh04L5PlLgHgRw==,type:str]
+    http-password: ENC[AES256_GCM,data:9Rmf3NvTZ+1qcT7n,iv:gcOairda29oWTlJbocPSGquWgYmAMHipqZYJ5fuxvhI=,tag:GElnS24N4kQohlvTOp2ZKQ==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/apc-prod-397611/locations/europe-west3/keyRings/sops/cryptoKeys/sops-key
+          created_at: "2026-05-22T07:24:29Z"
+          enc: CiQAhLiU4R3MiR/x5m7bTSZpe9XAOf+FXkU6H65s94w1PtXL3MISSQDOezfyKRAQ4TRuEcNSP8zXw2gj38OTmIPyWZ/FyPjvOqhMppVIOW9zS9HXZwoZXHY1CWZZtid9yN7FZ3hM5W83W5BayDTY5eE=
+    lastmodified: "2026-05-22T07:24:29Z"
+    mac: ENC[AES256_GCM,data:F7aGLATaAyHIvA5mzy+x5WMcln/xZZg0w6sMcw5x4/n/fyi5+sK2dEonr/3mw32mbtUCBTIu5YytdwnGXW22z7snAadiklmcRMYLeXYjiH8MquwjEA3IhPkuuqKkVroH3xDD1zV0s9A3NsI6woH7rH19MWkjaNnqNw4zs0xMrPU=,iv:izPgQTTaHYsHcseyqUSHjVltU+Ea2mjT7BV7EQp9vQs=,tag:TDxSvfc5p5H4a7+8eOxNHQ==,type:str]
+    encrypted_regex: ^(data)$
+    version: 3.11.0

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/staging/ksops-secret-generator.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/staging/ksops-secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./lahti-secret.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/staging/kustomization.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/staging/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://data.waltti.fi/lahti/api/gtfsrealtime/v1.0/feed/vehicleposition"
+      - "HTTP_URL=https://lsl.mattersoft.fi/api/gtfsrealtime/v1.0/feed/vehicleposition"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-staging/source/gtfsrt-vp-fi-lahti"
@@ -16,3 +16,6 @@ configMapGenerator:
 patches:
   - path: history-limit.yaml
   - path: resource-bursting.yaml
+
+generators:
+  - ./ksops-secret-generator.yaml

--- a/manifests/gtfsrt-vp-poller/lahti/overlays/staging/lahti-secret.yaml
+++ b/manifests/gtfsrt-vp-poller/lahti/overlays/staging/lahti-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: gtfsrt-vp-poller-fi-lahti
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+    labels:
+        app.kubernetes.io/instance: gtfsrt-vp-poller-fi-lahti
+data:
+    http-username: ENC[AES256_GCM,data:wsYe7NiLEOs=,iv:HzJTmZUXHcgyppXMJt7qqDdB+M4a6ewB6nDdgaWBcWQ=,tag:TfRrZjIyWxVAcG4fLmHtpg==,type:str]
+    http-password: ENC[AES256_GCM,data:ZaPxZJzN4lA3/rYa,iv:hwZ4SfA4IBD3sjFwnICFjSyMLsudMhZ1hBmjEPMn4Ys=,tag:aSi/p2lGI6xcjaiHbjuHpw==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/apc-staging-388907/locations/global/keyRings/sops/cryptoKeys/sops-key
+          created_at: "2026-05-22T07:24:28Z"
+          enc: CiQAUhREB2cgFnmRDlnTIlRELxRJueNauWKzu7F/eKAxHFsG0VQSSQD4ANZeuJTOummPKVc15JvBNtnbh2veLajLIFLasUoGN4onLnlgZ4JmdQTqhJof2DN+ylfkNRHAB6NWnOxkrESaGtC8xHPwIfo=
+    lastmodified: "2026-05-22T07:24:29Z"
+    mac: ENC[AES256_GCM,data:5gDEUBHXtu3frNgp35enV0Oc4RU07OZDJqecsfjFVNBnQLE0YGfTjTZ9qp0xYSKFxaZ9HfSnOCZXRYCxlT3iAU92Q5gB299wO84xlyqJt2h3D+Tf1gXi/iUp0ivx9DjOV7suGn/N8fNOTxzIY2FTZ+to2yZd6eoeDfw5xepXg3E=,iv:q+pX31aKV0F+Bq+aGhS7i71GnZJkW2x9+gahH+p3zLg=,tag:geo4xKoDzii3zdyR1fdL1g==,type:str]
+    encrypted_regex: ^(data)$
+    version: 3.11.0

--- a/manifests/vehicle-registry-poller/kuopio/overlays/dev/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/kuopio/overlays/dev/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://vilkkutestadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_URL=https://vilkkuadmin.mattersoft.fi/externalapi/assets/allvehicles"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=debug"
       - "PULSAR_TOPIC=persistent://apc-sandbox/source/vehicle-catalogue-fi-kuopio"

--- a/manifests/vehicle-registry-poller/kuopio/overlays/dev/vehicle-secret.yaml
+++ b/manifests/vehicle-registry-poller/kuopio/overlays/dev/vehicle-secret.yaml
@@ -7,19 +7,14 @@ metadata:
     labels:
         app.kubernetes.io/instance: vehicle-registry-poller-fi-kuopio
 data:
-    http-username: ENC[AES256_GCM,data:jVFjd0DltPQ=,iv:JDXF065Hev3posAFF4/TtZ//uZHYC7TLiPzLZykZUAM=,tag:7DncQKNbWuOtFBTz1fAfMQ==,type:str]
-    http-password: ENC[AES256_GCM,data:JUBSKn0VLOPnRQVCj+Kp1KHd5Vo=,iv:GTbV2KunIb5u+WYABvxCQlOqRo0O3mSmJXi7GwAu3XM=,tag:+a4OtwIGsFJ4DU6SPXoU8w==,type:str]
+    http-username: ENC[AES256_GCM,data:ONqYsAzM65o=,iv:CV1EO92Gv147G0OVitdflescMsaB8EQ3mJTd5uQwGgY=,tag:CKCVF85bgc7t9rK50mFZTA==,type:str]
+    http-password: ENC[AES256_GCM,data:l+K5A+QpZ9d1j5nvyjaK5Q==,iv:Oj4tlQpsyInx4uo20ZwFeaT+SsW9ImNlrL3RnNE1jSI=,tag:E+tKLfHY9PZ6RqRgBgVqkQ==,type:str]
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/apc-sandbox/locations/global/keyRings/sops/cryptoKeys/sops-key
           created_at: "2025-11-27T12:11:13Z"
           enc: CiQAQ7huFp5ZuMtSDkTdGzluimvVk9nurLuY7LhJ+v35klbcnCcSSQC//AyihuCfms0HsFt9vJWXPXguJ/w5kPU5LOO2xGLql5vRnJ7DvmqscrMPzyL/NJlaZ+FsKNKP9/tghQ5cmWGAk5bt7BKGQ84=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-11-27T12:11:13Z"
-    mac: ENC[AES256_GCM,data:YKkg/UVl+A1dXeT90yaozSr/PYgZb5+dyFRR9TBKzYxZtze5OtGu3OC5j+3DLHIVaoEYYs0Ac3fl9ohlS7x7LkKAYPPAwD6mUhVzPZk0BgsMhyqdo+hEU3iaSD0T+iaFbBGd5jw/if5f3iid33bmnQQQxOLuNhcBSlgJXd8dw+A=,iv:98B08fof/QzLOc8w5HGt4Xq78PeWMCF7BBtrS/DOv6M=,tag:1uUPNqP2uL0Os3KYGclxrg==,type:str]
-    pgp: []
+    lastmodified: "2026-05-22T07:22:24Z"
+    mac: ENC[AES256_GCM,data:4/Fb6kaRfPJ1YG/egKFlYFtU85tPffHbM7RqzjpC7vSM50O1KWQqvWwEMEqPjj1gkzm1B9CP4Aa/p2eFZwgLVrGdcS7HfKUx3vxScL/T5zmjc+CYfnbRztA9YXJ9NxdYa3HQT0bLnUe6v2L58OmnEwSMfSd1aBYTdCSaIjJmhoU=,iv:2iYNp0T315jHwhjcHiXxZKKfyES+MmEBBBy6/6MUE+4=,tag:+HMPsYLFZDEKg8xKSQiixQ==,type:str]
     encrypted_regex: ^(data)$
     version: 3.7.3

--- a/manifests/vehicle-registry-poller/kuopio/overlays/prod/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/kuopio/overlays/prod/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://vilkkutestadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_URL=https://vilkkuadmin.mattersoft.fi/externalapi/assets/allvehicles"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-prod/source/vehicle-catalogue-fi-kuopio"

--- a/manifests/vehicle-registry-poller/kuopio/overlays/prod/vehicle-secret.yaml
+++ b/manifests/vehicle-registry-poller/kuopio/overlays/prod/vehicle-secret.yaml
@@ -10,19 +10,14 @@ metadata:
     labels:
         app.kubernetes.io/instance: vehicle-registry-poller-fi-kuopio
 data:
-    http-username: ENC[AES256_GCM,data:BTMKNq2Swqg=,iv:Ckt01RVqIHcnqi/ekVFv6x0BCFqT7Axtgepxm1gaziY=,tag:En4windHPnf8nOA3yAZ1KA==,type:str]
-    http-password: ENC[AES256_GCM,data:Qb3aAb05f7rI2dnbclnw8lj8k4M=,iv:r92LvLdC2lqiHskE7nw2HkChvE3VGLADF2FqiyRMwBk=,tag:3Ch5QsZ/4lw8ufibHQtSQA==,type:str]
+    http-username: ENC[AES256_GCM,data:MsLJLcKYALk=,iv:zEemQY736H3haQtlZl/XxkXNvDg2Ut4iJ7xD7V0N9ws=,tag:RFz7XPi6pII+sf83U7ZsOw==,type:str]
+    http-password: ENC[AES256_GCM,data:tdzRPCiO/DrrvMn6RRYBYA==,iv:5BFYy29dLK21QVPqDdX/l37IGSGH9vSJhx6Zy563Qzc=,tag:qbR8eEFLeaz9uJweIXFMmA==,type:str]
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/apc-prod-397611/locations/europe-west3/keyRings/sops/cryptoKeys/sops-key
           created_at: "2025-12-03T12:55:49Z"
           enc: CiQAhLiU4fWgE6MF0RaWr6hVvj0zJHc3mkr/8BewsyM4LrOSt60SSQDOezfybutW4iLcC1My/AZBdWBInr+mPIwNTc9fEXfmSYbDzbb2p1IknmigLvq0e6BYZd22lQV22lCW1WBmOfLrSMEsxE9vnRE=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-12-03T12:55:49Z"
-    mac: ENC[AES256_GCM,data:LCsZsgXPCNofWR6/fRFiQj3GSIurlZHKIAES2zoRrymOqHmNrxchTsf+rfnH07UIIcSGN3xVTF/Z7UWYhGA717iv7ghqts0VkgVMgeeYvPLZOEMqscYV8kpJitCFa+AVw7aYovgdfK/y9Q54e8qGtSP1jIUgvoLApdDY8Z3ADCU=,iv:RCzExCrhqFJIXzCoWQh/0JOaFNNYkA5J1n1hPOslbkA=,tag:RcpNUqM2AJjCGca4vHttEw==,type:str]
-    pgp: []
+    lastmodified: "2026-05-22T07:22:28Z"
+    mac: ENC[AES256_GCM,data:Z9tuU5UsH81LG4LFlHaoo6sdRou5ffQSlI9PTc4lB6vvndpYlBfDwhnlpSUp37mvJVpE2m1j6JRz5MlZLGwOBiuJUZW33HUurleZibEzcSbbess7AMQI4x8OV9xWf/riRshuS+K6wD4paYagxzg9TJkvT55NWdo9VIrNSG2K6NM=,iv:mZELpAGLRQTvPMOdBtkIlsVgo7NQS8bd2qnmRhgUbR4=,tag:irIII8grfbWPQZGz/Et0EQ==,type:str]
     encrypted_regex: ^(data)$
     version: 3.7.3

--- a/manifests/vehicle-registry-poller/kuopio/overlays/staging/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/kuopio/overlays/staging/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://vilkkutestadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_URL=https://vilkkuadmin.mattersoft.fi/externalapi/assets/allvehicles"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-staging/source/vehicle-catalogue-fi-kuopio"

--- a/manifests/vehicle-registry-poller/kuopio/overlays/staging/vehicle-secret.yaml
+++ b/manifests/vehicle-registry-poller/kuopio/overlays/staging/vehicle-secret.yaml
@@ -7,19 +7,14 @@ metadata:
     labels:
         app.kubernetes.io/instance: vehicle-registry-poller-fi-kuopio
 data:
-    http-username: ENC[AES256_GCM,data:fnQxK5AR9uM=,iv:geq3ybRDeZsm8A2LNI3kDdVALbNuDuVpMJUws02bkvk=,tag:6sMm2ylyglz9QeSYUBV9GQ==,type:str]
-    http-password: ENC[AES256_GCM,data:QzXc1zagemqUKHTfSnLGvctl+0Y=,iv:AFsmWCEsgLx2u4U9A+KwTUGMpsdYxpRQmToKq1VubwY=,tag:bDPpz/qsA4/N+7Hb0t7L8A==,type:str]
+    http-username: ENC[AES256_GCM,data:06BO5NZpv1s=,iv:FYn/IG4GEKsbKHKW1yqQbZsfV5AvoIkKctZWGJ5K/bs=,tag:paa2l+ZnAgack7wwnup0yg==,type:str]
+    http-password: ENC[AES256_GCM,data:N3RrMc5dvwKEy1uDThHGQw==,iv:XkkRomooki9ZJ8/A8Uh66l3C6/Bfew+pia/T8IBxLiI=,tag:/iJNgVMMJAFKt97BMt5j9Q==,type:str]
 sops:
-    kms: []
     gcp_kms:
         - resource_id: projects/apc-staging-388907/locations/global/keyRings/sops/cryptoKeys/sops-key
           created_at: "2025-11-27T12:24:40Z"
           enc: CiQAUhREBy7w8o90FpjoXfE4LQeskjEyVJVmMGkwTZ4QyaShAB4SSQD4ANZeCk6AAZrffuSj130nwrR98P9sOF9nkpJXhtJkvUfUdIkhSUuwO5IjsCbfNUMhP7SKFy9Ruyap0IiQqYBD/Y7HJxOpYvs=
-    azure_kv: []
-    hc_vault: []
-    age: []
-    lastmodified: "2025-11-27T12:24:41Z"
-    mac: ENC[AES256_GCM,data:eNYcSrziDd1pdZp1Mr+L9ytwlektOQH8naoev59gFNgI5xjUEVpTnqU/7tMECMZsfE6M29Azzy9LzNSbI4Q8fTyu39yx42twyffYo11o8F1H8w5FfyPaOXkrV+4qLqSxnZhtxuRE0aSoOX1je19eI88zjYvJhTSEEw+gZUweoD0=,iv:Bm+d3r6uECe35lQnKwCt5LGvO5EJ0fUGGEIsvqZmkkM=,tag:Jc+ww7esDmuedvwBlbmxzw==,type:str]
-    pgp: []
+    lastmodified: "2026-05-22T07:22:26Z"
+    mac: ENC[AES256_GCM,data:qJviEVm5SkvdyoeODfQ9LMz+V+cijGmjGrBsjGul0e3GCRwRn+HIs0o4GSDxCx6ncShbrD/qtoPdmtgF9WxpWBQ3epFd/tKU+d7XywMLxvm6xVUJEUMrg4msMgeXxOX3MLqHSRg8TzXh6hQ7SHl7BMV4mn0L3gaI51E1SqnNCZw=,iv:gWXBH6ky/Gc0zhi4n4Df78C4D+Bf9OQuI6G1Re/C9fE=,tag:Nl/b0/M0UCCz3TbZE+9LHA==,type:str]
     encrypted_regex: ^(data)$
     version: 3.7.3

--- a/manifests/vehicle-registry-poller/lahti/overlays/dev/ksops-secret-generator.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/dev/ksops-secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./vehicle-secret.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/dev/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/dev/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://lahtiadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_URL=https://lsladmin.mattersoft.fi/externalapi/assets/allvehicles"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=debug"
       - "PULSAR_TOPIC=persistent://apc-sandbox/source/vehicle-catalogue-fi-lahti"
@@ -16,3 +16,6 @@ configMapGenerator:
 patches:
   - path: history-limit.yaml
   - path: resource-bursting.yaml
+
+generators:
+  - ./ksops-secret-generator.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/dev/vehicle-secret.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/dev/vehicle-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: vehicle-registry-poller-fi-lahti
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+    labels:
+        app.kubernetes.io/instance: vehicle-registry-poller-fi-lahti
+data:
+    http-username: ENC[AES256_GCM,data:uT5GSL0XDhg=,iv:2aXLqII1YG8J91U/mJiFCp9FfpAVgiyJTcKQI7P1FH0=,tag:av89LgMRaZYlMeJXrX+xdg==,type:str]
+    http-password: ENC[AES256_GCM,data:zfhoCiynFV6wPZqK+7xQMw==,iv:EBVWLlKSApgaODlhQ4ipCWxhsty3Mj4TiAEwWGGFC98=,tag:xmIds7L0LKTpY/HXeHlmwg==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/apc-sandbox/locations/global/keyRings/sops/cryptoKeys/sops-key
+          created_at: "2026-05-22T07:24:26Z"
+          enc: CiQAQ7huFqySykX8oF39ahqpqR4Iq0K6LN8lJyxJ2eII0Yx9ot8SSQC//Ayi1p5t0o2K8xildRaveIO88yirOlDwKuvrz7dLYLfKqLQbDwUJVsHev8QHyynfuCrIL5eZn+0QItZDwQXQQRjYLxNpGyo=
+    lastmodified: "2026-05-22T07:36:55Z"
+    mac: ENC[AES256_GCM,data:aWaAcIbDzpi30yD0OkipRTbjF/ZfiODJKVS5hXLL6OyL5s1K6Zgi+fcVk7bg1s41kwJwmgDGtZHn1ZrKq6c7dHbg33Q/tx7VYRhhr44qhR/vUeTpIJVfZa4ldvFY3wQmeakqF5bcsxvuSDq8VkVpBDlJX9IIPMusoswbnAuQvb0=,iv:dbFdYPvr9Vt9YFm+ALxhwyDjhFiNxzDxxu73FszcrUU=,tag:IAYIj1hKO5NKCNUXs9uQFQ==,type:str]
+    encrypted_regex: ^(data)$
+    version: 3.11.0

--- a/manifests/vehicle-registry-poller/lahti/overlays/prod/ksops-secret-generator.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/prod/ksops-secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./vehicle-secret.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/prod/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/prod/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://lahtiadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_URL=https://lsladmin.mattersoft.fi/externalapi/assets/allvehicles"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-prod/source/vehicle-catalogue-fi-lahti"
@@ -15,3 +15,6 @@ configMapGenerator:
       - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
 patches:
   - path: history-limit.yaml
+
+generators:
+  - ./ksops-secret-generator.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/prod/vehicle-secret.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/prod/vehicle-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: vehicle-registry-poller-fi-lahti
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+    labels:
+        app.kubernetes.io/instance: vehicle-registry-poller-fi-lahti
+data:
+    http-username: ENC[AES256_GCM,data:9U9o0PTSHpM=,iv:4SUC8mTR57YFQtIgw4LXnrF0p3cCCV8zw/OwXCckK9o=,tag:C3GYfgdNd0nYbqg9kZx0aA==,type:str]
+    http-password: ENC[AES256_GCM,data:FGyQEfWzSReXe0eUMkzyWw==,iv:D2w5S7aZnMWGNpWgZrnEa/EjZP29T1cMBCK/00iSDVE=,tag:AZVTsrxQGx2qiEQDIs02zw==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/apc-prod-397611/locations/europe-west3/keyRings/sops/cryptoKeys/sops-key
+          created_at: "2026-05-22T07:24:27Z"
+          enc: CiQAhLiU4Wle7NnyDcggxIX6dAYNP5EtZ5nDJNnLtb+V1mnLJcgSSQDOezfyOxEcqVDJ0b6xr+l8zFvurV4axsN1Np7JGdlNYB3BGsVFYwrooageVN2CvAfFsCO7c9E+jnVxsHCYww0fhXZA1429Dwo=
+    lastmodified: "2026-05-22T07:36:57Z"
+    mac: ENC[AES256_GCM,data:967FtCHNF95fPnsdNmRwBNAZ4iP3Mnfp/moS72/1ETokOaOwy3pEC4vOlDAWMPmnD5AdtwwQ/ynvXbN0Ri0Nz1NBBlFeNYOB7GuocDpmSFyG9Rh4KbCkCCqpNAzT9wpMTDdlgS31Q4/VcIpMtATDW4yyhF7hOFx38wcj/hztmaE=,iv:rxZWy1I1P3rXFmShmVaUkFUj+Lz45pExjMWeHAmrMGI=,tag:pKl1ME4PzZ+ts7L3sJGm6A==,type:str]
+    encrypted_regex: ^(data)$
+    version: 3.11.0

--- a/manifests/vehicle-registry-poller/lahti/overlays/staging/ksops-secret-generator.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/staging/ksops-secret-generator.yaml
@@ -1,0 +1,10 @@
+apiVersion: viaduct.ai/v1
+kind: ksops
+metadata:
+  name: ksops-secret-generator
+  annotations:
+    config.kubernetes.io/function: |
+      exec:
+        path: ksops
+files:
+  - ./vehicle-secret.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/staging/kustomization.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/staging/kustomization.yaml
@@ -7,7 +7,7 @@ configMapGenerator:
     behavior: merge
     literals:
       - "HTTP_PASSWORD_PATH=/secrets/http-password"
-      - "HTTP_URL=https://lahtiadmin.mattersoft.fi/externalapi/assets/allvehicles"
+      - "HTTP_URL=https://lsladmin.mattersoft.fi/externalapi/assets/allvehicles"
       - "HTTP_USERNAME_PATH=/secrets/http-username"
       - "PINO_LOG_LEVEL=info"
       - "PULSAR_TOPIC=persistent://apc-staging/source/vehicle-catalogue-fi-lahti"
@@ -16,3 +16,6 @@ configMapGenerator:
 patches:
   - path: history-limit.yaml
   - path: resource-bursting.yaml
+
+generators:
+  - ./ksops-secret-generator.yaml

--- a/manifests/vehicle-registry-poller/lahti/overlays/staging/vehicle-secret.yaml
+++ b/manifests/vehicle-registry-poller/lahti/overlays/staging/vehicle-secret.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Secret
+metadata:
+    name: vehicle-registry-poller-fi-lahti
+    annotations:
+        kustomize.config.k8s.io/behavior: replace
+    labels:
+        app.kubernetes.io/instance: vehicle-registry-poller-fi-lahti
+data:
+    http-username: ENC[AES256_GCM,data:xSiHR70Eroo=,iv:xf8qCSOIFNEtrZ+UB1fx+Cp08qROY5bsUs7pq6+EQ4s=,tag:0L5a/bMqmSfMFGbzhk4vqg==,type:str]
+    http-password: ENC[AES256_GCM,data:VJJkntckr1v33ySbaIskTA==,iv:vk2Tjnrlr3LMGo4N90XHluRuQu8sKUBrP/2bS+ze2ac=,tag:Z0SYuiZy72ipOLMxq+wqXg==,type:str]
+sops:
+    gcp_kms:
+        - resource_id: projects/apc-staging-388907/locations/global/keyRings/sops/cryptoKeys/sops-key
+          created_at: "2026-05-22T07:24:26Z"
+          enc: CiQAUhREByCl2kFzVqb+xCJgWyT+myKO0/iR9thGIcGA3QxziFQSSQD4ANZe2rYnYHKuy3A5frXqjjFuIdHZXVdVjC7csY+QeaRNQ/hwNdEguGkWy3R9FNRek7MlCmNGrm58YgfkOlFJOSUBqH9kg/o=
+    lastmodified: "2026-05-22T07:36:56Z"
+    mac: ENC[AES256_GCM,data:OC6W906kyS2omrXPLrlJlc6tyQxUPOGy7EAoZ0W7Eex6YdpqepnUT9kuKpezzqndZdW7CnjfovUqQWZWJs+N1cJYJ6006LRtjl1Wo1xbw9xsEtfkp29uov/7Ysf1HQO6gJ5pnIAvOJ6emyfxC90W3gV6IvZdgx/bZar+cIX5tFA=,iv:/t4orkr17z0Ou85tO8YNBGeDg2SQR695NoFXcumG4GY=,tag:N34R8pPIZJn8hHL4hsRKTA==,type:str]
+    encrypted_regex: ^(data)$
+    version: 3.11.0


### PR DESCRIPTION
## Summary
- update Kuopio and Lahti vehicle registry and GTFS-RT endpoint URLs across dev/staging/prod
- update Kuopio encrypted poller credentials
- add encrypted Lahti poller credentials with environment-specific SOPS KMS keys

## Verification
- rendered all affected overlays with `kustomize build --enable-alpha-plugins --enable-exec`
- applied affected overlays live to dev/staging/prod
- restarted affected poller deployments
- verified live Kubernetes secrets match local env-file values without printing secret values
- direct HTTP checks returned 200 for Kuopio registry, Kuopio GTFS-RT, Lahti registry, and Lahti GTFS-RT

Note: autosync is temporarily disabled on the affected Argo apps while this PR is pending.