### PR TITLE
Increase splitter ephemeral storage in non-prod

### DIFF
--- a/manifests/vehicle-position-splitter/jyvaskyla/overlays/dev/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/jyvaskyla/overlays/dev/resource-bursting.yaml
@@ -11,8 +11,8 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi
             limits:
               cpu: 500m
               memory: 512Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi

--- a/manifests/vehicle-position-splitter/jyvaskyla/overlays/staging/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/jyvaskyla/overlays/staging/resource-bursting.yaml
@@ -11,8 +11,8 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi
             limits:
               cpu: 500m
               memory: 512Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi

--- a/manifests/vehicle-position-splitter/kuopio/overlays/dev/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/kuopio/overlays/dev/resource-bursting.yaml
@@ -11,8 +11,8 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi
             limits:
               cpu: 500m
               memory: 512Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi

--- a/manifests/vehicle-position-splitter/kuopio/overlays/staging/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/kuopio/overlays/staging/resource-bursting.yaml
@@ -11,8 +11,8 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi
             limits:
               cpu: 500m
               memory: 512Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi

--- a/manifests/vehicle-position-splitter/lahti/overlays/dev/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/dev/resource-bursting.yaml
@@ -11,8 +11,8 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi
             limits:
               cpu: 500m
               memory: 512Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi

--- a/manifests/vehicle-position-splitter/lahti/overlays/staging/resource-bursting.yaml
+++ b/manifests/vehicle-position-splitter/lahti/overlays/staging/resource-bursting.yaml
@@ -11,8 +11,8 @@ spec:
             requests:
               cpu: 50m
               memory: 256Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi
             limits:
               cpu: 500m
               memory: 512Mi
-              ephemeral-storage: 100Mi
+              ephemeral-storage: 512Mi


### PR DESCRIPTION
## Summary
- raise dev/staging vehicle-position-splitter ephemeral-storage request and limit from 100Mi to 512Mi for Jyvaskyla, Kuopio, and Lahti
- prevents startup/catch-up evictions seen in staging and sandbox

## Verification
- kustomize build for all edited dev/staging splitter overlays
- applied live to staging and sandbox; all splitters rolled out 1/1 with 0 restarts