### PR TITLE
Pin splitter image digest

### DIFF
--- a/manifests/vehicle-position-splitter/base/deployment.yaml
+++ b/manifests/vehicle-position-splitter/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: vehicle-position-splitter
-          image: tvvlmj/waltti-apc-vehicle-position-splitter:edge
+          image: tvvlmj/waltti-apc-vehicle-position-splitter:8b9f458ca6604b52134f6897b4468c301dc64164520d9d9ff11f32b1c9e0486b
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
## Summary
- pin vehicle-position-splitter base image to the verified digest deployed in prod, staging, and sandbox
- avoids future drift through the mutable edge tag

## Verification
- kustomize build for Jyvaskyla, Kuopio, and Lahti prod overlays
- live deployments in prod/staging/sandbox are already running this digest 1/1