### PR TITLE
Restore known-good splitter image digest

### DIFF
--- a/manifests/vehicle-position-splitter/base/deployment.yaml
+++ b/manifests/vehicle-position-splitter/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: vehicle-position-splitter
-          image: tvvlmj/waltti-apc-vehicle-position-splitter:8b9f458ca6604b52134f6897b4468c301dc64164520d9d9ff11f32b1c9e0486b
+          image: tvvlmj/waltti-apc-vehicle-position-splitter:1e6c2cebc943b647ba2dd8f3857c578a7fd145b3cf7202cda139846b04c3fa79
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Restores the splitter base image pin to the currently healthy digest after the newly published image showed a native crash in prod Kuopio.