### PR TITLE
Pin splitter to registry timeout fix image

### DIFF
--- a/manifests/vehicle-position-splitter/base/deployment.yaml
+++ b/manifests/vehicle-position-splitter/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: vehicle-position-splitter
-          image: tvvlmj/waltti-apc-vehicle-position-splitter:1e6c2cebc943b647ba2dd8f3857c578a7fd145b3cf7202cda139846b04c3fa79
+          image: tvvlmj/waltti-apc-vehicle-position-splitter@sha256:df94d6ceb3c5a0442f5df6a315c6de177786dd13738682627d7eed0d48f10a94
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Pins vehicle-position-splitter to the main image containing the registry reader timeout crash fix. Live prod/staging/sandbox have already been rolled to this digest and watchdog is green.