### PR TITLE
Use edge tag for splitter image

### DIFF
--- a/manifests/vehicle-position-splitter/base/deployment.yaml
+++ b/manifests/vehicle-position-splitter/base/deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: vehicle-position-splitter
-          image: tvvlmj/waltti-apc-vehicle-position-splitter@sha256:df94d6ceb3c5a0442f5df6a315c6de177786dd13738682627d7eed0d48f10a94
+          image: tvvlmj/waltti-apc-vehicle-position-splitter:edge
           imagePullPolicy: Always
           resources:
             requests:


### PR DESCRIPTION
Restores the vehicle-position-splitter deployment manifest to use the normal edge tag instead of pinning a digest in the deployment repo. The edge tag currently points to the merged registry-reader timeout fix image.