### PR TITLE
[codex] Use edge image for prod MQTT inspector

### DIFF
--- a/manifests/mqtt-message-inspector/overlays/prod/kustomization.yaml
+++ b/manifests/mqtt-message-inspector/overlays/prod/kustomization.yaml
@@ -2,10 +2,6 @@ namespace: prod
 resources:
   - ../../base
 
-images:
-  - name: tvvlmj/waltti-apc-mqtt-message-inspector
-    newTag: sha-41ec8d406b4e5f0174994ba4d44b7ca35e4cbaf1
-
 configMapGenerator:
   - name: mqtt-message-inspector
     behavior: merge


### PR DESCRIPTION
## What changed

Remove the prod `mqtt-message-inspector` image tag override so the overlay inherits the base `tvvlmj/waltti-apc-mqtt-message-inspector:edge` image.

## Why

Prod was pinned to an old inspector image, so the MQTT raw capture writer reconnect fix merged in the inspector repo could not reach prod through the normal image flow.

## Validation

- Rendered prod overlay with `kustomize build --enable-alpha-plugins --enable-exec` and confirmed the deployment image is `tvvlmj/waltti-apc-mqtt-message-inspector:edge`.
- Prod was updated live with `kubectl set image` to `:edge`; the new pod is ready and pulled digest `sha256:315aacd56761916132942939bd5831230c575704baf9727a7ec1058953df0259`.
- MQTT inspector capture is fresh after rollout.
