### PR TITLE
[codex] Enable date partitioning for prod MQTT inspector

### DIFF
--- a/manifests/mqtt-message-inspector/overlays/prod/kustomization.yaml
+++ b/manifests/mqtt-message-inspector/overlays/prod/kustomization.yaml
@@ -13,6 +13,7 @@ configMapGenerator:
       - CAPTURE_GCS_PROJECT_ID=apc-sandbox
       - CAPTURE_GCS_BUCKET=waltti-apc-mqtt-message-inspector-sandbox
       - CAPTURE_GCS_PREFIX=runs
+      - CAPTURE_PARTITION_BY_UTC_DATE=true
       - CAPTURE_DASHBOARD_INTERVAL_SECONDS=300
       - CAPTURE_GCS_UPLOAD_INTERVAL_SECONDS=300
       - PINO_LOG_LEVEL=info


### PR DESCRIPTION
## What changed

Enables `CAPTURE_PARTITION_BY_UTC_DATE=true` for the prod MQTT message inspector.

## Why

The inspector code now supports date-partitioned capture paths. Prod should use that layout so GCS data is visible under daily prefixes instead of only process-start run folders.

## Validation

- Inspected diff: one prod inspector config-map literal added
