### PR TITLE
[codex] Fix prod MQTT deduplication window

### DIFF
--- a/manifests/mqtt-deduplicator/overlays/prod/kustomization.yaml
+++ b/manifests/mqtt-deduplicator/overlays/prod/kustomization.yaml
@@ -11,11 +11,9 @@ configMapGenerator:
       - "PINO_LOG_LEVEL=info"
       # - "PULSAR_OAUTH2_AUDIENCE=urn:sn:pulsar:waltti:prod"
       - "PULSAR_SERVICE_URL=pulsar://pulsar-broker.pulsar.svc.cluster.local:6650"
-      - "DEDUPLICATION_WINDOW_IN_SECONDS=0"
-      - "CACHE_WINDOW_IN_SECONDS=0"
+      - "DEDUPLICATION_WINDOW_IN_SECONDS=3600"
+      - "CACHE_WINDOW_IN_SECONDS=172800"
       - "PULSAR_CACHE_READER_RECEIVER_QUEUE_SIZE=10"
-      - "CACHE_REBUILD_DISABLE_SEEK=true"
       
 patches:
   - path: history-limit.yaml
-


### PR DESCRIPTION
## Summary
- restore a non-zero prod MQTT deduplication window
- restore cache warm-up for the prod MQTT deduplicator
- stop disabling timestamp seek during cache warm-up

## Why
The prod overlay set `DEDUPLICATION_WINDOW_IN_SECONDS=0` and `CACHE_WINDOW_IN_SECONDS=0`, which made the deduplicator effectively unable to retain message digests. With three MQTT forwarder replicas, duplicate APC vehicle messages could pass through to the journey matcher and inflate `apc/v1` counts by 2x or 3x.

## Validation
- `git diff --check`
- `kustomize build manifests/mqtt-deduplicator/overlays/prod` renders `DEDUPLICATION_WINDOW_IN_SECONDS: "3600"` and `CACHE_WINDOW_IN_SECONDS: "172800"`, with no `CACHE_REBUILD_DISABLE_SEEK` override.
