### PR TITLE
Fix production APC passenger-count accumulation image

### DIFF
--- a/manifests/anonymizer/overlays/prod/kustomization.yaml
+++ b/manifests/anonymizer/overlays/prod/kustomization.yaml
@@ -2,6 +2,13 @@ namespace: prod
 resources:
   - ../../base
 
+images:
+  - name: tvvlmj/waltti-apc-anonymizer
+    # Contains the passenger-count accumulation fix and the Node/Pulsar
+    # stability fixes. Pin the immutable multi-platform digest so production
+    # cannot silently resolve an older or newer `edge` image.
+    digest: sha256:1a9ddbfd09d65f3588e657d03fb305a1640ab454b48ab8018592fcce7290d8f0
+
 configMapGenerator:
   - name: anonymizer
     behavior: merge
@@ -23,4 +30,3 @@ configMapGenerator:
 
 patches:
   - path: history-limit.yaml
-


### PR DESCRIPTION
## Summary

- pin the production anonymizer to immutable image digest `sha256:1a9ddbfd09d65f3588e657d03fb305a1640ab454b48ab8018592fcce7290d8f0`
- deploy application revision `762b6af2854cfc908c69517fc0c7155170fee0b4`, which includes the passenger-count accumulation fix and the Node/Pulsar stability fixes
- prevent the production deployment from silently resolving a stale or incompatible `edge` image

## Verification

- verified OCI revision label
- inspected compiled image code for journey field comparison, cumulative passenger count, and stale-count reset
- rendered the production Kustomize overlay and confirmed the immutable digest