### PR TITLE
Restore anonymizer edge image convention

### DIFF
--- a/manifests/anonymizer/overlays/prod/kustomization.yaml
+++ b/manifests/anonymizer/overlays/prod/kustomization.yaml
@@ -2,13 +2,6 @@ namespace: prod
 resources:
   - ../../base
 
-images:
-  - name: tvvlmj/waltti-apc-anonymizer
-    # Contains the passenger-count accumulation fix and the Node/Pulsar
-    # stability fixes. Pin the immutable multi-platform digest so production
-    # cannot silently resolve an older or newer `edge` image.
-    digest: sha256:1a9ddbfd09d65f3588e657d03fb305a1640ab454b48ab8018592fcce7290d8f0
-
 configMapGenerator:
   - name: anonymizer
     behavior: merge


### PR DESCRIPTION
## Summary

- revert the production-only anonymizer digest override added in #161
- keep the anonymizer aligned with the repository-wide `edge` image convention and Dependabot-driven release flow
- leave the production manifest free of incident-specific comments

The operational correction is to reapply the existing production overlay and roll the workload so Kubernetes resolves the current `edge` image.